### PR TITLE
fixed extraction for arXiv IDs with a scheme

### DIFF
--- a/src/arxiv.js
+++ b/src/arxiv.js
@@ -5,11 +5,11 @@ function extract(str) {
 }
 
 function extractPre2007Ids(str) {
-    return extractIds(str, /(?:^|\s|\/)((?:arXiv:)?[a-z-]+(?:\.[A-Z]{2})?\/\d{2}(?:0[1-9]|1[012])\d{3}(?:v\d+)?(?=$|\s))/gi);
+    return extractIds(str, /(?:^|\s|\/|arXiv:)([a-z-]+(?:\.[A-Z]{2})?\/\d{2}(?:0[1-9]|1[012])\d{3}(?:v\d+)?(?=$|\s))/gi);
 }
 
 function extractPost2007Ids(str) {
-    return extractIds(str, /(?:^|\s|\/)((?:arXiv:)?\d{4}\.\d{4,5}(?:v\d+)?(?=$|\s))/gi);
+    return extractIds(str, /(?:^|\s|\/|arXiv:)(\d{4}\.\d{4,5}(?:v\d+)?(?=$|\s))/gi);
 }
 
 function extractIds(str, re) {


### PR DESCRIPTION
These tests were failing:
```js
test("extracts pre-2007 arXiv IDs with a scheme", () => {
    expect(arxiv.extract("arXiv:math.GT/0309136")).toEqual(["math.GT/0309136"]);
});
```
and 
```js
test("extracts post-2007 arXiv IDs with a scheme", () => {
    expect(arxiv.extract("Example: arXiv:0706.0001")).toEqual(["0706.0001"]);
});
```

Fixed the regex string
